### PR TITLE
Solved endless polling issue

### DIFF
--- a/reloadr.js
+++ b/reloadr.js
@@ -20,7 +20,7 @@ TO USE: include reloadr.js and tell it what to check:
 		'/css/layout.css'
 	]);
 */
-
+var continue_poll = true;
 var Reloadr = {
 	options: {
 		frequency: 2000,
@@ -70,10 +70,13 @@ var Reloadr = {
 		for (i in urls)
 			this.ajax.call(this, urls[i], function() {
 				if (this > Date.parse(window._Reloadr_LoadTime))
+					continue_poll = false;
 					location.reload();
 			});
 
-		this.go();
+		if (continue_poll) {
+			this.go();
+		}
 	},
 	init: function(options) {
 		window._Reloadr_LoadTime = new Date();

--- a/reloadr.js
+++ b/reloadr.js
@@ -69,9 +69,10 @@ var Reloadr = {
 		// check 'em
 		for (i in urls)
 			this.ajax.call(this, urls[i], function() {
-				if (this > Date.parse(window._Reloadr_LoadTime))
+				if (this > Date.parse(window._Reloadr_LoadTime)) {
 					continue_poll = false;
 					location.reload();
+				}
 			});
 
 		if (continue_poll) {


### PR DESCRIPTION
Browser will stop previous location.reload() action when a new
location.reload() action is fired, if the first fire doesn't complete
before the second, you get an endless loop of location.reload() that
never finishes.
